### PR TITLE
Update README.md:  renamed prev -> previous

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Signals supports several reactive operators
  * `sampleon`
  * `foldp`
  * `count`
- * `prev`
+ * `previous`
  * `merge`
  * `async_signal`
  * `remote_signal`


### PR DESCRIPTION
simple one-line update to README.md to rename operator prev->previous to reflect existing code